### PR TITLE
Enabled generalized implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-cycles"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Andreas Maier <andreas.martin.maier@desy.de>"]
 description = "Detect all cycles in a petgraph graph"


### PR DESCRIPTION
Currently, Cycles is only implemented for Graph.
However, other graph type implementations are also desirable.
A blanket implementation for all graph types `G` that implement  `IntoNodeIdentifiers + IntoNeighbors + NodeIndexable` was proposed in a comment in main.
However, most graphs only implement these traits on `&G`, making the trait unusable on, e.g., `petgraph::graph::Graph` .

Moving the trait constraint to `&G` solves this issue, but introduces a second issue that methods on those traits implemented for `&G` return node identifiers associated with `&G`, but other functions we use require node identifiers associated with `G`. For graphs in petgraph, those associated types are the same. But the blanket implementation can not know that.

Instead, we require that the associated NodeID types be convertible in a type constraint
```
    for<'a>   <Graph as GraphBase>::NodeId: From<<&'a Graph as GraphBase>::NodeId>
```
This constraint is satisfied whenever both types are identical through a blanket implementation in the standard library.

We add two tests showing that the blanket implementation now applies to both `petgraph::graph::Graph` and `petgraph::graphmap::GraphMap`.